### PR TITLE
fix: add configurable deploymentStrategy, default Recreate for hostNetwork safety

### DIFF
--- a/charts/factorio/Chart.yaml
+++ b/charts/factorio/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/factorio/templates/deployment.yaml
+++ b/charts/factorio/templates/deployment.yaml
@@ -6,6 +6,13 @@ metadata:
     {{- include "factorio.labels" . | nindent 4 }}
 spec:
   replicas: 1
+  strategy:
+    type: {{ .Values.deploymentStrategy.type }}
+    {{- if eq .Values.deploymentStrategy.type "RollingUpdate" }}
+    rollingUpdate:
+      maxSurge: {{ .Values.deploymentStrategy.rollingUpdate.maxSurge }}
+      maxUnavailable: {{ .Values.deploymentStrategy.rollingUpdate.maxUnavailable }}
+    {{- end }}
   selector:
     matchLabels:
       {{- include "factorio.selectorLabels" . | nindent 6 }}

--- a/charts/factorio/values.yaml
+++ b/charts/factorio/values.yaml
@@ -110,6 +110,14 @@ volumeMounts:
   #  mountPath: "/server-settings.json"
   #  key: "server-settings"
 
+# Recreate is the safe default: hostNetwork: true binds game ports directly to the
+# host NIC — RollingUpdate deadlocks waiting for ports to be freed by the old pod.
+deploymentStrategy:
+  type: Recreate
+  rollingUpdate:   # only used when type: RollingUpdate
+    maxSurge: 1
+    maxUnavailable: 0
+
 nodeSelector: { }
 
 tolerations: [ ]


### PR DESCRIPTION
## Problem
	emplates/deployment.yaml had no \strategy\ field, so Kubernetes defaulted to \RollingUpdate\. With \hostNetwork: true\, the game ports (34197/UDP + 27015/TCP) are bound directly to the host NIC — the new pod can never start because the old pod holds the ports, leaving the deployment stuck \Pending\ forever.
## Changes
- **\	emplates/deployment.yaml\** — Added configurable \strategy\ block; \ollingUpdate\ sub-fields only rendered when \	ype: RollingUpdate\
- **\alues.yaml\** — Added \deploymentStrategy\ with \	ype: Recreate\ as safe default
- **\Chart.yaml\** — Bumped version \