### PR TITLE
feat(emby): add env and envFrom passthrough

### DIFF
--- a/charts/emby/Chart.yaml
+++ b/charts/emby/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.0
+version: 1.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/emby/templates/deployment.yaml
+++ b/charts/emby/templates/deployment.yaml
@@ -41,6 +41,14 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: {{ .Values.service.external.portName }}
               containerPort: {{ .Values.service.external.port }}

--- a/charts/emby/values.yaml
+++ b/charts/emby/values.yaml
@@ -65,6 +65,25 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
+# Environment variables passed to the emby container.
+# The emby/embyserver image runs s6-overlay as root for init, then drops
+# privileges to the user/group specified by UID/GID/GIDLIST env vars.
+# Example for running emby as host uid:gid 8096:
+# env:
+#   - name: UID
+#     value: "8096"
+#   - name: GID
+#     value: "8096"
+#   - name: GIDLIST
+#     value: "8096"
+env: []
+
+# Environment variables sourced from ConfigMaps or Secrets.
+# envFrom:
+#   - secretRef:
+#       name: emby-secrets
+envFrom: []
+
 service:
   type: ClusterIP
   local:


### PR DESCRIPTION
## Summary
- Add `env:` and `envFrom:` passthrough to the emby chart's container spec.
- Bump chart version 1.1.0 → 1.2.0.

## Why
The `emby/embyserver` image uses s6-overlay: PID 1 must start as root so s6 can init, then it drops privileges to the user/group named by env vars `UID` / `GID` / `GIDLIST`.

Before this change the only way to influence the runtime uid was `securityContext.runAsUser` / `runAsNonRoot`, which prevents s6 from initializing (`s6-mkdir: unable to mkdir /var/run/s6: Permission denied`). With this change, callers can set a dedicated host user (e.g. uid 8096) via env vars and leave the s6 init flow intact.

## Backward compatibility
`env` and `envFrom` default to `[]`. When empty, the `{{- with }}` guard skips the block — rendered output is byte-identical to 1.1.0 for existing deployments.

## Test plan
- [x] `helm lint charts/emby` — passes
- [x] `helm template charts/emby` (no env) — no `env:` block emitted
- [x] `helm template charts/emby --set env[0].name=UID,env[0].value=8096,...` — env block renders correctly inside the container spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)