### PR TITLE
fix(emby): omit securityContext block when values are empty

### DIFF
--- a/charts/emby/Chart.yaml
+++ b/charts/emby/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.0
+version: 1.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/emby/templates/deployment.yaml
+++ b/charts/emby/templates/deployment.yaml
@@ -32,13 +32,17 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.podSecurityContext }}
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       hostNetwork: {{ .Values.hostNetwork }}
       containers:
         - name: {{ .Chart.Name }}
+          {{- with .Values.securityContext }}
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- with .Values.env }}


### PR DESCRIPTION
## Summary
- Wrap pod-level and container-level `securityContext` in `{{- with }}` guards so the block is fully omitted when values are empty.
- Bump chart 1.2.0 → 1.2.1.

## Why
With the previous template, an unset `securityContext` rendered as `securityContext: {}`. Helm's 3-way merge cannot remove nested fields when transitioning from a populated map to an empty one — fields like `runAsUser`, `runAsGroup`, `runAsNonRoot` from a prior release survive on the upgraded Deployment.

This bit me on the emby/embyserver image: it uses s6-overlay which must start as root, so a leftover `runAsNonRoot: true` from a previous values revision keeps blocking startup with `s6-mkdir: unable to mkdir /var/run/s6: Permission denied` even after the values are removed.

Omitting the block entirely (rather than rendering `{}`) lets Helm's diff correctly strip the stale fields.

## Test plan
- [x] `helm lint charts/emby` — passes
- [x] `helm template charts/emby` (defaults) — no `securityContext` keys in output
- [x] `helm template charts/emby --set podSecurityContext.fsGroup=8096 --set securityContext.runAsUser=8096` — both blocks render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)